### PR TITLE
Fix new URL

### DIFF
--- a/.github/license-check/header-py.txt
+++ b/.github/license-check/header-py.txt
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
-# This file is part of SpiegieMon. https://github.com/Spiegie/Spiegiemon_piedition/
+# This file is part of SpiegieMon. https://github.com/SpiegieMon/Spiegiemon_piedition/
 # (C) 2022 Michael Spiegelhalter <michael.spi@web.de>

--- a/bluetooth_queue_adapter.py
+++ b/bluetooth_queue_adapter.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# This file is part of SpiegieMon. https://github.com/Spiegie/Spiegiemon_piedition/
+# This file is part of SpiegieMon. https://github.com/SpiegieMon/Spiegiemon_piedition/
 # (C) 2022 Michael Spiegelhalter <michael.spi@web.de>
 import queue
 import sys

--- a/console_input.py
+++ b/console_input.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# This file is part of SpiegieMon. https://github.com/Spiegie/Spiegiemon_piedition/
+# This file is part of SpiegieMon. https://github.com/SpiegieMon/Spiegiemon_piedition/
 # (C) 2022 Michael Spiegelhalter <michael.spi@web.de>
 from queue import Queue
 from threading import Thread

--- a/lora_receiver.py
+++ b/lora_receiver.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# This file is part of SpiegieMon. https://github.com/Spiegie/Spiegiemon_piedition/
+# This file is part of SpiegieMon. https://github.com/SpiegieMon/Spiegiemon_piedition/
 # (C) 2022 Michael Spiegelhalter <michael.spi@web.de>
 import select
 from queue import Queue

--- a/lora_sender.py
+++ b/lora_sender.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# This file is part of SpiegieMon. https://github.com/Spiegie/Spiegiemon_piedition/
+# This file is part of SpiegieMon. https://github.com/SpiegieMon/Spiegiemon_piedition/
 # (C) 2022 Michael Spiegelhalter <michael.spi@web.de>
 import time
 from queue import Queue

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# This file is part of SpiegieMon. https://github.com/Spiegie/Spiegiemon_piedition/
+# This file is part of SpiegieMon. https://github.com/SpiegieMon/Spiegiemon_piedition/
 # (C) 2022 Michael Spiegelhalter <michael.spi@web.de>
 
 import sys

--- a/sx126x.py
+++ b/sx126x.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# This file is part of SpiegieMon. https://github.com/Spiegie/Spiegiemon_piedition/
+# This file is part of SpiegieMon. https://github.com/SpiegieMon/Spiegiemon_piedition/
 # (C) 2022 Michael Spiegelhalter <michael.spi@web.de>
 
 # parts here are based on code from WaveShare and modified/fixed:


### PR DESCRIPTION
The repo was moved, so we need the new URL in copyright notices